### PR TITLE
Error in ES query of learning paths

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -215,7 +215,9 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         filter_dictionary.update({
             'start':
             _format_filter(
-                DateRange(None, datetime.utcnow()))
+                DateRange(None, datetime.utcnow()),
+                missing_included=False
+            )
         })
     elif start == 'future':
         if sort_args == '+display_name':
@@ -232,7 +234,9 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         filter_dictionary.update({
             'start':
             _format_filter(
-                DateRange(datetime.utcnow(), None))
+                DateRange(datetime.utcnow(), None),
+                missing_included=False
+            )
         })
     else:
         if sort_args == '+display_name':
@@ -322,7 +326,8 @@ def programs_discovery_search(search_term=None, size=20, from_=0, field_dictiona
         filter_dictionary.update(
             {
                 'start': _format_filter(
-                    DateRange(None, datetime.utcnow())
+                    DateRange(None, datetime.utcnow()),
+                    missing_included=False
                 )
             }
         )
@@ -330,7 +335,8 @@ def programs_discovery_search(search_term=None, size=20, from_=0, field_dictiona
         filter_dictionary.update(
             {
                 'start': _format_filter(
-                    DateRange(datetime.utcnow(), None)
+                    DateRange(datetime.utcnow(), None),
+                    missing_included=False
                 )
             }
         )


### PR DESCRIPTION
# Task
 - https://foundever.atlassian.net/browse/TRIB-1242

# Issue descrption
 - The return of LearningPath in explore page ( https://apac-myacademy.learning-tribes.com/explore/?filter_type=learning_paths ) is always empty even there should be learning paths that can be shown.
 - And the error response of request as follow : 
```
"strptime() argument 1 must be string, not None"
```
 - And the log in edx-search shown that [LearningPath 1](https://studio-apac-myacademy.learning-tribes.com/program_detail/?program_uuid=fe68c156-02b9-4ca4-b011-b23a14502c3f) + [LearningPath 2](https://studio-apac-myacademy.learning-tribes.com/program_detail/?program_uuid=5d82cb4c-1083-4554-87de-e929456d015b) caused this issue.
