### PR TITLE
CMS homepage performance

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -312,7 +312,8 @@ def course_discovery_search(search_terms=None, size=20, from_=0, field_dictionar
         filter_dictionary=filter_dictionary,
         exclude_dictionary=exclude_dictionary,
         facet_terms=course_discovery_facets(),
-        sort=sort_args
+        sort=sort_args,
+        ga_total=kwargs.pop('ga_total', False)
     )
 
     return process_range_data(results)

--- a/search/api.py
+++ b/search/api.py
@@ -377,7 +377,8 @@ def programs_discovery_search(search_terms=None, size=20, from_=0, field_diction
         filter_dictionary=filter_dictionary,
         exclude_dictionary=exclude_dictionary,
         facet_terms=program_discovery_facets(),
-        sort=sort_args
+        sort=sort_args,
+        ga_total=kwargs.pop('ga_total', False)
     )
 
     return process_range_data(results)

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -58,6 +58,10 @@ def _translate_hits(es_response):
     if "facets" in es_response:
         response["facets"] = {facet: translate_facet(es_response["facets"][facet]) for facet in es_response["facets"]}
 
+    if "aggregations" in es_response and "total_records" in es_response["aggregations"]:
+        # Total number without Filters
+        response["doc_count"] = es_response["aggregations"]["total_records"]["doc_count"]
+
     return response
 
 

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -716,8 +716,8 @@ class ElasticSearchEngine(SearchEngine):
         # Get `doc_count` from ES ( without filters )
         # E.g: if we query courses with lots of conditions, then we still return total count of
         # courses with this Flag `ga_total`
-        _ga_total = kwargs.pop('ga_total', None)
-        if _ga_total:
+        ga_total = kwargs.pop('ga_total', None)
+        if ga_total:
             body['aggs'] = {
                 "total_records": {
                     "global": {}

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 RESERVED_CHARACTERS = "+=><!(){}[]^~*:\\/&|?"
 
 
-def _translate_hits(es_response):
+def _translate_hits(es_response, total_keys=None):
     """ Provide resultset in our desired format from elasticsearch results """
 
     def translate_result(result):
@@ -61,9 +61,9 @@ def _translate_hits(es_response):
     if "aggregations" in es_response and "total_records" in es_response["aggregations"]:
         # Total number without Filters
         response["doc_count"] = es_response["aggregations"]["total_records"]["doc_count"]
-        if "filtered_id" in es_response["aggregations"]["total_records"]:
+        if total_keys is not None:
             # For some low level Roles: counting for specified course_keys / program_uuids
-            response["doc_count"] = es_response["aggregations"]["total_records"]["filtered_id"]["doc_count"]
+            response["doc_count"] = total_keys
 
     return response
 
@@ -719,22 +719,20 @@ class ElasticSearchEngine(SearchEngine):
         # Get `doc_count` from ES ( without filters )
         # E.g: if we query courses with lots of conditions, then we still return total count of
         # courses with this Flag `ga_total`
+        total_keys = None
         ga_total = kwargs.pop('ga_total', None)
         if ga_total:
+            ### For high level Roles:
             body["aggs"] = {
                 "total_records": {
                     "global": {}
                 }
             }
             ### For low level Roles:
-            if "course" in field_dictionary:    # Courses
-                body["aggs"]["total_records"]["aggs"] = {
-                    "filtered_id": {"filter": {"terms": {"_id": field_dictionary["course"]}}}
-                }
-            if "uuid" in field_dictionary:      # Learning Paths
-                body["aggs"]["total_records"]["aggs"] = {
-                    "filtered_id": {"filter": {"terms": {"uuid": field_dictionary["uuid"]}}}
-                }
+            if "course" in field_dictionary:                # Courses
+                total_keys = len(field_dictionary["course"])
+            if "uuid" in field_dictionary:                  # Learning Paths
+                total_keys = len(field_dictionary["uuid"])
 
         try:
             log.info("search body: %s", body)
@@ -754,4 +752,4 @@ class ElasticSearchEngine(SearchEngine):
                 log.exception("error while searching index - %s", ex.message)
                 raise
 
-        return _translate_hits(es_response)
+        return _translate_hits(es_response, total_keys)

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -727,11 +727,11 @@ class ElasticSearchEngine(SearchEngine):
                 }
             }
             ### For low level Roles:
-            if field_dictionary.get("course", None):    # Courses
+            if "course" in field_dictionary:    # Courses
                 body["aggs"]["total_records"]["aggs"] = {
                     "filtered_id": {"filter": {"terms": {"_id": field_dictionary["course"]}}}
                 }
-            if field_dictionary.get("uuid", None):      # Learning Paths
+            if "uuid" in field_dictionary:      # Learning Paths
                 body["aggs"]["total_records"]["aggs"] = {
                     "filtered_id": {"filter": {"terms": {"uuid": field_dictionary["uuid"]}}}
                 }

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -709,6 +709,16 @@ class ElasticSearchEngine(SearchEngine):
         _sort_args_in_body = kwargs.pop('sort', None)
         if _sort_args_in_body:
             body['sort'] = _sort_args_in_body
+        # Get `doc_count` from ES ( without filters )
+        # E.g: if we query courses with lots of conditions, then we still return total count of
+        # courses with this Flag `ga_total`
+        _ga_total = kwargs.pop('ga_total', None)
+        if _ga_total:
+            body['aggs'] = {
+                "total_records": {
+                    "global": {}
+                }
+            }
 
         try:
             log.info("search body: %s", body)

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -61,6 +61,9 @@ def _translate_hits(es_response):
     if "aggregations" in es_response and "total_records" in es_response["aggregations"]:
         # Total number without Filters
         response["doc_count"] = es_response["aggregations"]["total_records"]["doc_count"]
+        if "filtered_id" in es_response["aggregations"]["total_records"]:
+            # For some low level Roles: counting for specified course_keys / program_uuids
+            response["doc_count"] = es_response["aggregations"]["total_records"]["filtered_id"]["doc_count"]
 
     return response
 
@@ -718,11 +721,19 @@ class ElasticSearchEngine(SearchEngine):
         # courses with this Flag `ga_total`
         ga_total = kwargs.pop('ga_total', None)
         if ga_total:
-            body['aggs'] = {
+            body["aggs"] = {
                 "total_records": {
                     "global": {}
                 }
             }
+            if field_dictionary.get("course", None):
+                body["aggs"]["total_records"]["aggs"] = {
+                    "filtered_id": {"filter": {"terms": {"_id": field_dictionary["course"]}}}
+                }
+            if field_dictionary.get("uuid", None):
+                body["aggs"]["total_records"]["aggs"] = {
+                    "filtered_id": {"filter": {"terms": {"uuid": field_dictionary["uuid"]}}}
+                }
 
         try:
             log.info("search body: %s", body)
@@ -731,6 +742,7 @@ class ElasticSearchEngine(SearchEngine):
                 body=body,
                 **kwargs
             )
+
         except exceptions.ElasticsearchException as ex:
             message = unicode(ex)
             if 'QueryParsingException' in message:

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -726,11 +726,12 @@ class ElasticSearchEngine(SearchEngine):
                     "global": {}
                 }
             }
-            if field_dictionary.get("course", None):
+            ### For low level Roles:
+            if field_dictionary.get("course", None):    # Courses
                 body["aggs"]["total_records"]["aggs"] = {
                     "filtered_id": {"filter": {"terms": {"_id": field_dictionary["course"]}}}
                 }
-            if field_dictionary.get("uuid", None):
+            if field_dictionary.get("uuid", None):      # Learning Paths
                 body["aggs"]["total_records"]["aggs"] = {
                     "filtered_id": {"filter": {"terms": {"uuid": field_dictionary["uuid"]}}}
                 }


### PR DESCRIPTION
# Task 
 - https://foundever.atlassian.net/browse/TRIB-1614

# Tested
 - Returned the following counting data structure in the data of Courses/Programs : 
```
......
  , u'aggregations': {u'total_records': {u'doc_count': 25}}   <--- total number of courses without filters
  , u'took': 69, 
  u'timed_out': False
}


Sample Log: 
[contentstore.views.discovery_api] discovery_api.py:310 - 17 courses find ( Total number: 25 ).
```



